### PR TITLE
Adjust how buttons are added into closure panel

### DIFF
--- a/WME Closure Helper Beta.user.js
+++ b/WME Closure Helper Beta.user.js
@@ -443,7 +443,7 @@ var G_AMOUNTOFPRESETS = 100;
         var tmpButtonClicks = 0;
         var first = null;
         //alert("Appending node.");
-        $("#segment-edit-closures").append("<div style='margin-top: 10px;'></div>");
+        $("#segment-edit-closures .closures-list").append("<div id='wmech-container' style='margin-top: 10px;'></div>");
         var presetCount = 1;
         for (presetCount = 1; presetCount < G_AMOUNTOFPRESETS; presetCount++) {
             var nameInput = $("#wmech_preset" + presetCount + "name").val();
@@ -451,7 +451,7 @@ var G_AMOUNTOFPRESETS = 100;
             var color = $(".wmech_colorinput").eq(presetCount - 1).val();
             var textColor = getTextContrastColor(color);
             if (nameInput) {
-                $("#segment-edit-closures").append(
+                $("#wmech-container").append(
                     $('<button>', {
                         id: ('wmechButton' + presetCount),
                         class: 'wmech_closurebutton',
@@ -481,8 +481,6 @@ var G_AMOUNTOFPRESETS = 100;
         $(".dates").css("margin-left", "10px");
         $(".closure-title").css("padding", "0").css("min-height", "19px");
         $(".buttons").css("top", "0px");
-        $("#sidebar .tab-content").css("overflow", "visible").css("overflow-x", "visibile");
-        $(".closures-list-items").css({"overflow-y": "visible", "padding": 0});
     }
 
     function addEnhancedClosureHistory() {

--- a/WME Closure Helper.user.js
+++ b/WME Closure Helper.user.js
@@ -443,7 +443,7 @@ var G_AMOUNTOFPRESETS = 100;
         var tmpButtonClicks = 0;
         var first = null;
         //alert("Appending node.");
-        $("#segment-edit-closures").append("<div style='margin-top: 10px;'></div>");
+        $("#segment-edit-closures .closures-list").append("<div id='wmech-container' style='margin-top: 10px;'></div>");
         var presetCount = 1;
         for (presetCount = 1; presetCount < G_AMOUNTOFPRESETS; presetCount++) {
             var nameInput = $("#wmech_preset" + presetCount + "name").val();
@@ -451,7 +451,7 @@ var G_AMOUNTOFPRESETS = 100;
             var color = $(".wmech_colorinput").eq(presetCount - 1).val();
             var textColor = getTextContrastColor(color);
             if (nameInput) {
-                $("#segment-edit-closures").append(
+                $("#wmech-container").append(
                     $('<button>', {
                         id: ('wmechButton' + presetCount),
                         class: 'wmech_closurebutton',
@@ -481,8 +481,6 @@ var G_AMOUNTOFPRESETS = 100;
         $(".dates").css("margin-left", "10px");
         $(".closure-title").css("padding", "0").css("min-height", "19px");
         $(".buttons").css("top", "0px");
-        $("#sidebar .tab-content").css("overflow", "visible").css("overflow-x", "visibile");
-        $(".closures-list-items").css({"overflow-y": "visible", "padding": 0});
     }
 
     function addEnhancedClosureHistory() {


### PR DESCRIPTION
This avoids changing CSS overflow and gives a container that could potentially be used to collapse the presets section (this may need to be an option for people that have a bunch of presets. The latest WME condenses the closure list in order to always show the native Add Closure button and thus the WMECH buttons - see this segment for an example of a long list of closures where the buttons are always shown: https://www.waze.com/en-US/editor?env=usa&lon=-77.95207&lat=34.25247&zoom=6&segments=503977592)